### PR TITLE
Fixed broken ease out animation

### DIFF
--- a/src/components/Pricing/Pricing.elements.js
+++ b/src/components/Pricing/Pricing.elements.js
@@ -50,6 +50,7 @@ export const PricingCard = styled(Link)`
   height: 500px;
   text-decoration: none;
   border-radius: 4px;
+  transition: all 0.3s ease-out;
 
   &:nth-child(2) {
     margin: 24px;
@@ -57,7 +58,6 @@ export const PricingCard = styled(Link)`
 
   &:hover {
     transform: scale(1.06);
-    transition: all 0.3s ease-out;
     color: #1c2237;
   }
 


### PR DESCRIPTION
The ease out animation for the price cards was not working due to this issue: https://stackoverflow.com/questions/14488757/css-transition-ease-out-not-working
The issue was fixed by moving the transform attribute.